### PR TITLE
🐛 bugfix: wizard import gaf netwerkfout

### DIFF
--- a/backend/templates/leerkracht.html
+++ b/backend/templates/leerkracht.html
@@ -846,13 +846,15 @@ async function bevestigImport() {
     const strategy = document.querySelector('input[name="mergeStrategy"]:checked')?.value || 'skip_existing';
     if (!klasId || !importWizardData) return;
 
+    // Sla de vakken op VOOR sluitImportModal() importWizardData op null zet
+    const vakken = importWizardData.vakken;
     sluitImportModal();
     showNotification('Bezig met importeren...', 'warning');
     try {
         const res = await fetch('/api/assessments/bulk-import', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({ class_id: klasId, vakken: importWizardData.vakken, merge_strategy: strategy })
+            body: JSON.stringify({ class_id: klasId, vakken, merge_strategy: strategy })
         });
         const result = await res.json();
         if (!res.ok) { showNotification(result.error || 'Import mislukt', 'error'); return; }


### PR DESCRIPTION
sluitImportModal() wordt aangeroepen vóór de fetch, en die functie zet importWizardData = null. Dan probeert de fetch importWizardData.vakken te gebruiken — maar dat is al null, wat een JS exception gooit die door de catch wordt opgepikt als "netwerkfout".Edited a file, ran a command, read a fileEdited a file, ran a command, read a fileDe volgorde was: sluitImportModal() → importWizardData = null → fetch probeert null.vakken te lezen → crash. Nu worden de vakken eerst in een lokale variabele opgeslagen, daarna pas het modal gesloten.